### PR TITLE
[Session1 #2] 天気予報アプリの画面レイアウトを構成する

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,7 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       home: WeatherScreen(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_training/weather_screen.dart';
 
 void main() {
   runApp(const MainApp());
@@ -9,12 +10,8 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: Text('Hello World!'),
-        ),
-      ),
+    return MaterialApp(
+      home: WeatherScreen(),
     );
   }
 }

--- a/lib/weather_screen.dart
+++ b/lib/weather_screen.dart
@@ -1,70 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_training/weather_screen_buttons.dart';
+import 'package:flutter_training/weather_screen_temperature.dart';
 
 class WeatherScreen extends StatelessWidget {
   const WeatherScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final labelLarge = Theme.of(context).textTheme.labelLarge;
-
-    return Scaffold(
+    return const Scaffold(
       body: Center(
         child: FractionallySizedBox(
           widthFactor: 0.5,
           child: Column(
             children: [
-              const Spacer(),
-              const AspectRatio(
+              Spacer(),
+              AspectRatio(
                 aspectRatio: 1,
                 child: Placeholder(),
               ),
-              const SizedBox(height: 16),
-              Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      '** ℃',
-                      textAlign: TextAlign.center,
-                      style: labelLarge?.copyWith(
-                        color: Colors.blue,
-                      ), // TextStyle(color: Colors.blue),
-                    ),
-                  ),
-                  Expanded(
-                    child: Text(
-                      '** ℃',
-                      textAlign: TextAlign.center,
-                      style: labelLarge?.copyWith(
-                        color: Colors.red,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Expanded(
-                child: Column(
-                  children: [
-                    const SizedBox(height: 80),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextButton(
-                            onPressed: () {},
-                            child: const Text('Close'),
-                          ),
-                        ),
-                        Expanded(
-                          child: TextButton(
-                            onPressed: () {},
-                            child: const Text('Reload'),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
+              SizedBox(height: 16),
+              WeatherScreenTemperature(),
+              SizedBox(height: 16),
+              WeatherScreenButtons(),
             ],
           ),
         ),

--- a/lib/weather_screen.dart
+++ b/lib/weather_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class WeatherScreen extends StatelessWidget {
+  const WeatherScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final labelLarge = Theme.of(context).textTheme.labelLarge;
+
+    return Scaffold(
+      body: Center(
+        child: FractionallySizedBox(
+          widthFactor: 0.5,
+          child: Column(
+            children: [
+              const Spacer(),
+              const AspectRatio(
+                aspectRatio: 1,
+                child: Placeholder(),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '** ℃',
+                      textAlign: TextAlign.center,
+                      style: labelLarge?.copyWith(
+                        color: Colors.blue,
+                      ), // TextStyle(color: Colors.blue),
+                    ),
+                  ),
+                  Expanded(
+                    child: Text(
+                      '** ℃',
+                      textAlign: TextAlign.center,
+                      style: labelLarge?.copyWith(
+                        color: Colors.red,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: Column(
+                  children: [
+                    const SizedBox(height: 80),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextButton(
+                            onPressed: () {},
+                            child: const Text('Close'),
+                          ),
+                        ),
+                        Expanded(
+                          child: TextButton(
+                            onPressed: () {},
+                            child: const Text('Reload'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/weather_screen.dart
+++ b/lib/weather_screen.dart
@@ -21,7 +21,14 @@ class WeatherScreen extends StatelessWidget {
               SizedBox(height: 16),
               WeatherScreenTemperature(),
               SizedBox(height: 16),
-              WeatherScreenButtons(),
+              Expanded(
+                child: Column(
+                  children: [
+                    SizedBox(height: 80),
+                    WeatherScreenButtons(),
+                  ],
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/weather_screen_buttons.dart
+++ b/lib/weather_screen_buttons.dart
@@ -5,28 +5,21 @@ class WeatherScreenButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Column(
-        children: [
-          const SizedBox(height: 80),
-          Row(
-            children: [
-              Expanded(
-                child: TextButton(
-                  onPressed: () {},
-                  child: const Text('Close'),
-                ),
-              ),
-              Expanded(
-                child: TextButton(
-                  onPressed: () {},
-                  child: const Text('Reload'),
-                ),
-              ),
-            ],
+    return Row(
+      children: [
+        Expanded(
+          child: TextButton(
+            onPressed: () {},
+            child: const Text('Close'),
           ),
-        ],
-      ),
+        ),
+        Expanded(
+          child: TextButton(
+            onPressed: () {},
+            child: const Text('Reload'),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/weather_screen_buttons.dart
+++ b/lib/weather_screen_buttons.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class WeatherScreenButtons extends StatelessWidget {
+  const WeatherScreenButtons({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        children: [
+          const SizedBox(height: 80),
+          Row(
+            children: [
+              Expanded(
+                child: TextButton(
+                  onPressed: () {},
+                  child: const Text('Close'),
+                ),
+              ),
+              Expanded(
+                child: TextButton(
+                  onPressed: () {},
+                  child: const Text('Reload'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/weather_screen_temperature.dart
+++ b/lib/weather_screen_temperature.dart
@@ -15,7 +15,7 @@ class WeatherScreenTemperature extends StatelessWidget {
             textAlign: TextAlign.center,
             style: labelLarge?.copyWith(
               color: Colors.blue,
-            ), // TextStyle(color: Colors.blue),
+            ),
           ),
         ),
         Expanded(

--- a/lib/weather_screen_temperature.dart
+++ b/lib/weather_screen_temperature.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class WeatherScreenTemperature extends StatelessWidget {
+  const WeatherScreenTemperature({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final labelLarge = Theme.of(context).textTheme.labelLarge;
+
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            '** ℃',
+            textAlign: TextAlign.center,
+            style: labelLarge?.copyWith(
+              color: Colors.blue,
+            ), // TextStyle(color: Colors.blue),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            '** ℃',
+            textAlign: TextAlign.center,
+            style: labelLarge?.copyWith(
+              color: Colors.red,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 課題

close #2 

## 対応箇所

# 天気予報アプリの画面レイアウトを構成する

## 課題

- [x]  [Placeholder] の幅は画面の幅の半分
- [x] 青字と赤字の [Text] の幅は [Placeholder] の幅の半分

- [x] [Placeholder] の高さと幅は同じ


- [x] [Text] の上下に 16 logical pixel のパディング
- [x] [Text] の文字は `** ℃`
- [x] [Text] の水平位置は中央
- [x] [Text] のスタイルは `Theme.of(context).textTheme` で取得してきた `TextTheme` の [`labelLarge`]
- [x] [Text] の色は左が [`Colors.blue`]、右が [`Colors.red`]


- [x] [Placeholder] の水平中央は画面の中央と同じ
- [x] [Placeholder] と [Text] を合わせた矩形の垂直中央は画面の中央と同じ


- [x] [Text] と [TextButton] の隙間は 80 logical pixel


- [x] [Text] と [TextButton] の水平中央は同じ


## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| 期待値 | iPhone | Android |
|----------|--------|--------|
| <img  src="https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/layout/horizontal-ratio.png?raw=true">      |<img width="320" src="https://github.com/user-attachments/assets/731ef39e-4405-47db-b603-2d448045b0ba">    | <img width="320"  src="https://github.com/user-attachments/assets/565dc419-fda8-47b3-aaae-b8a3687b3643">
 |




