### PR TITLE
[Session3] #4 StatefulWidget のライフサイクル

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_training/screen/weather_screen.dart';
+import 'package:flutter_training/screen/splash_screen.dart';
 
 void main() {
   runApp(const MainApp());
@@ -11,7 +11,7 @@ class MainApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: WeatherScreen(),
+      home: SplashScreen(),
     );
   }
 }

--- a/lib/screen/splash_screen.dart
+++ b/lib/screen/splash_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ffi';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_training/screen/weather_screen.dart';
@@ -15,22 +16,22 @@ class _SplashScreenState extends State<SplashScreen> {
   void initState() {
     super.initState();
 
-    _navigateToNextScreen();
+    unawaited(_navigateToWeatherScreen());
   }
 
-  Future<void> _navigateToNextScreen() async {
+  Future<void> _navigateToWeatherScreen() async {
     await SchedulerBinding.instance.endOfFrame;
-    await Future.delayed(const Duration(milliseconds: 500));
+    await Future<void>.delayed(const Duration(milliseconds: 500));
     if (mounted) {
       await Navigator.push(
         context,
         MaterialPageRoute<void>(
-          builder: (BuildContext context) {
+          builder: (context) {
             return const WeatherScreen();
           },
         ),
       );
-      unawaited(_navigateToNextScreen());
+      unawaited(_navigateToWeatherScreen());
     }
   }
 

--- a/lib/screen/splash_screen.dart
+++ b/lib/screen/splash_screen.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_training/screen/weather_screen.dart';
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+
+    _navigateToNextScreen();
+  }
+
+  Future<void> _navigateToNextScreen() async {
+    await SchedulerBinding.instance.endOfFrame;
+    await Future.delayed(Duration(microseconds: 500));
+    if (mounted) {
+      await Navigator.push(
+        context,
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) {
+            return const WeatherScreen();
+          },
+        ),
+      );
+      unawaited(_navigateToNextScreen());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Colors.green,
+      body: SizedBox.expand(),
+    );
+  }
+}

--- a/lib/screen/splash_screen.dart
+++ b/lib/screen/splash_screen.dart
@@ -20,7 +20,7 @@ class _SplashScreenState extends State<SplashScreen> {
 
   Future<void> _navigateToNextScreen() async {
     await SchedulerBinding.instance.endOfFrame;
-    await Future.delayed(Duration(microseconds: 500));
+    await Future.delayed(const Duration(milliseconds: 500));
     if (mounted) {
       await Navigator.push(
         context,
@@ -38,7 +38,6 @@ class _SplashScreenState extends State<SplashScreen> {
   Widget build(BuildContext context) {
     return const Scaffold(
       backgroundColor: Colors.green,
-      body: SizedBox.expand(),
     );
   }
 }

--- a/lib/screen/splash_screen.dart
+++ b/lib/screen/splash_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ffi';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_training/screen/weather_screen.dart';

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -33,6 +33,9 @@ class _WeatherScreenState extends State<WeatherScreen> {
                   children: [
                     const SizedBox(height: 80),
                     WeatherScreenButtons(
+                      close: () {
+                        Navigator.pop(context);
+                      },
                       reload: () {
                         setState(() {
                           _weatherCondition = _api.fetchWeatherCondition();

--- a/lib/screen/weather_screen_buttons.dart
+++ b/lib/screen/weather_screen_buttons.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 
 class WeatherScreenButtons extends StatelessWidget {
-  const WeatherScreenButtons({required void Function() reload, super.key})
-      : _reload = reload;
+  const WeatherScreenButtons({
+    required void Function() close,
+    required void Function() reload,
+    super.key,
+  })  : _close = close,
+        _reload = reload;
 
+  final void Function() _close;
   final void Function() _reload;
 
   @override
@@ -12,7 +17,7 @@ class WeatherScreenButtons extends StatelessWidget {
       children: [
         Expanded(
           child: TextButton(
-            onPressed: () {},
+            onPressed: _close,
             child: const Text('Close'),
           ),
         ),


### PR DESCRIPTION
## 課題

close #4

## 対応箇所

- [x] [StatefulWidget] を継承した Widget で構築された新しい画面を追加する
- [x] 新しい画面の背景色は [`Colors.green`] に設定する
- [x] アプリ起動時に新しい画面に遷移する
- [x] 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
- [x] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる

## 動作

| 期待値 | iPhone | Android |
|----------|--------|--------|
| ![demo] |<video width="320" src="https://github.com/user-attachments/assets/374abdcb-f407-4d7b-8c78-ea5031ec95eb"> | <video width="320"  src="https://github.com/user-attachments/assets/4ccf6055-b8f8-418d-902c-24457c155192"> |

[demo]: https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/lifecycle/demo.gif?raw=true

