### PR TITLE
[Session5] #6 API のエラーハンドリング

### DIFF
--- a/lib/data/weather_api.dart
+++ b/lib/data/weather_api.dart
@@ -4,6 +4,28 @@ class WeatherAPI {
   final yumemiWeather = YumemiWeather();
 
   String fetchWeatherCondition() {
-    return yumemiWeather.fetchSimpleWeather();
+    try {
+      return yumemiWeather.fetchThrowsWeather('tokyo');
+    } on YumemiWeatherError catch (error) {
+      switch (error) {
+        case YumemiWeatherError.invalidParameter:
+          throw const InvalidParameter();
+        case YumemiWeatherError.unknown:
+          throw const Unknown();
+      }
+    }
   }
+}
+
+sealed class WeatherAPIError implements Exception {
+  const WeatherAPIError({required this.message});
+  final String message;
+}
+
+class InvalidParameter extends WeatherAPIError {
+  const InvalidParameter() : super(message: '無効な都道府県が指定されました');
+}
+
+class Unknown extends WeatherAPIError {
+  const Unknown() : super(message: '天気情報が取得できません');
 }

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -39,13 +39,13 @@ class _WeatherScreenState extends State<WeatherScreen> {
                         Navigator.pop(context);
                       },
                       reload: () {
-                        setState(() {
-                          try {
+                        try {
+                          setState(() {
                             _weatherCondition = _api.fetchWeatherCondition();
-                          } on WeatherAPIError catch (error) {
-                            unawaited(_showErrorDialog(error.message));
-                          }
-                        });
+                          });
+                        } on WeatherAPIError catch (error) {
+                          unawaited(_showErrorDialog(error.message));
+                        }
                       },
                     ),
                   ],
@@ -67,7 +67,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
           title: Text(message),
           actions: <Widget>[
             TextButton(
-              child: const Text('Ok'),
+              child: const Text('OK'),
               onPressed: () {
                 Navigator.of(context).pop();
               },

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_training/data/weather_api.dart';
 import 'package:flutter_training/screen/weather_icon.dart';
@@ -38,7 +40,11 @@ class _WeatherScreenState extends State<WeatherScreen> {
                       },
                       reload: () {
                         setState(() {
-                          _weatherCondition = _api.fetchWeatherCondition();
+                          try {
+                            _weatherCondition = _api.fetchWeatherCondition();
+                          } on WeatherAPIError catch (error) {
+                            unawaited(_showErrorDialog(error.message));
+                          }
                         });
                       },
                     ),
@@ -49,6 +55,26 @@ class _WeatherScreenState extends State<WeatherScreen> {
           ),
         ),
       ),
+    );
+  }
+
+  Future<void> _showErrorDialog(String message) async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false, // user must tap button!
+      builder: (context) {
+        return AlertDialog(
+          title: Text(message),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('Ok'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## 課題

close #6 

## 対応箇所

- [x] 使用する API を `fetchSimpleWeather()` から `fetchThrowsWeather()` に変更する
- [x] API のエラーを補足して、エラーの内容に応じて [AlertDialog] でメッセージを表示する
    - メッセージの内容は自由
- [x] [AlertDialog] の OK ボタンをタップすると、ダイアログを閉じる

## 動作

| iPhone | Android |
|----------|--------|
| <video width="320"  src="https://github.com/user-attachments/assets/cc3517f9-cb47-47d4-a46c-abc62908c584">| <video width="320"  src="https://github.com/user-attachments/assets/2d356f6d-5cc5-4533-8e64-ce9363f3381e">|






