### PR TITLE
[Session 11] #12 スレッドブロック

### DIFF
--- a/lib/data/api/weather_api.dart
+++ b/lib/data/api/weather_api.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_training/data/api/provider/yumemi_weather_provider.dart';
 import 'package:flutter_training/domain/exception/app_exception.dart';
@@ -20,13 +21,16 @@ class WeatherAPI {
 
   final YumemiWeather _yumemiWeather;
 
-  String fetchWeatherInfo({String area = 'tokyo', DateTime? dateTime}) {
+  Future<String> fetchWeatherInfo({
+    String area = 'tokyo',
+    DateTime? dateTime,
+  }) async {
     final dateTimeLocal = dateTime ?? DateTime.now();
 
     final request = jsonEncode(toJson((area: area, dateTime: dateTimeLocal)));
 
     try {
-      return _yumemiWeather.fetchWeather(request);
+      return await compute(_yumemiWeather.syncFetchWeather, request);
     } on YumemiWeatherError catch (error) {
       switch (error) {
         case YumemiWeatherError.invalidParameter:

--- a/lib/data/repository/weather_repository.dart
+++ b/lib/data/repository/weather_repository.dart
@@ -22,8 +22,10 @@ class WeatherRepository {
 
   final WeatherAPI _weatherAPI;
 
-  Future<WeatherInfo> getWeatherInfo(
-      {String area = 'tokyo', DateTime? dateTime}) async {
+  Future<WeatherInfo> getWeatherInfo({
+    String area = 'tokyo',
+    DateTime? dateTime,
+  }) async {
     final json =
         await _weatherAPI.fetchWeatherInfo(area: area, dateTime: dateTime);
 

--- a/lib/data/repository/weather_repository.dart
+++ b/lib/data/repository/weather_repository.dart
@@ -22,8 +22,10 @@ class WeatherRepository {
 
   final WeatherAPI _weatherAPI;
 
-  WeatherInfo getWeatherInfo({String area = 'tokyo', DateTime? dateTime}) {
-    final json = _weatherAPI.fetchWeatherInfo(area: area, dateTime: dateTime);
+  Future<WeatherInfo> getWeatherInfo(
+      {String area = 'tokyo', DateTime? dateTime}) async {
+    final json =
+        await _weatherAPI.fetchWeatherInfo(area: area, dateTime: dateTime);
 
     final weatherInfo = jsonDecode(json) as Map<String, dynamic>;
 

--- a/lib/ui/provider/weather_info_notifier_provider.dart
+++ b/lib/ui/provider/weather_info_notifier_provider.dart
@@ -13,10 +13,10 @@ class WeatherInfoNotifier extends _$WeatherInfoNotifier {
   }
 
   // 関数があるProvideerは、Notifierを付ける
-  void fetch({String area = 'tokyo', DateTime? dateTime}) {
+  Future<void> fetch({String area = 'tokyo', DateTime? dateTime}) async {
     final repository = ref.read(weatherRepositoryProvider);
 
-    state = repository.getWeatherInfo(
+    state = await repository.getWeatherInfo(
       area: area,
       dateTime: dateTime,
     );

--- a/lib/ui/provider/weather_info_notifier_provider.dart
+++ b/lib/ui/provider/weather_info_notifier_provider.dart
@@ -12,7 +12,7 @@ class WeatherInfoNotifier extends _$WeatherInfoNotifier {
     return null;
   }
 
-  // 関数があるProvideerは、Notifierを付ける
+  // 関数があるProviderは、Notifierを付ける
   Future<void> fetch({String area = 'tokyo', DateTime? dateTime}) async {
     final repository = ref.read(weatherRepositoryProvider);
 

--- a/lib/ui/provider/weather_info_notifier_provider.g.dart
+++ b/lib/ui/provider/weather_info_notifier_provider.g.dart
@@ -9,7 +9,7 @@ part of 'weather_info_notifier_provider.dart';
 // **************************************************************************
 
 String _$weatherInfoNotifierHash() =>
-    r'a4285c965a44e8ac0fe1d6fdd43e98370edcb0d0';
+    r'50846468594827a80e2923a1f832f8876abf6743';
 
 /// See also [WeatherInfoNotifier].
 @ProviderFor(WeatherInfoNotifier)

--- a/lib/ui/screen/weather_screen.dart
+++ b/lib/ui/screen/weather_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_training/ui/provider/weather_info_notifier_provider.dart
 import 'package:flutter_training/ui/screen/weather_icon.dart';
 import 'package:flutter_training/ui/screen/weather_screen_buttons.dart';
 import 'package:flutter_training/ui/screen/weather_screen_temperature.dart';
+import 'package:flutter_training/ui/utils/async_task_indicator.dart';
 
 class WeatherScreen extends ConsumerWidget {
   const WeatherScreen({super.key});
@@ -33,13 +34,18 @@ class WeatherScreen extends ConsumerWidget {
                       close: () {
                         Navigator.pop(context);
                       },
-                      reload: () {
+                      reload: () async {
                         try {
-                          ref
-                              .read(weatherInfoNotifierProvider.notifier)
-                              .fetch();
+                          await performTaskWithLoadingIndicator(
+                            context: context,
+                            task: () => ref
+                                .read(weatherInfoNotifierProvider.notifier)
+                                .fetch(),
+                          );
                         } on AppException catch (error) {
-                          unawaited(_showErrorDialog(context, error.message));
+                          if (context.mounted) {
+                            unawaited(_showErrorDialog(context, error.message));
+                          }
                         }
                       },
                     ),

--- a/lib/ui/utils/async_task_indicator.dart
+++ b/lib/ui/utils/async_task_indicator.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+/// 非同期の実行中にローディングインジケーターを表示する
+Future<T> performTaskWithLoadingIndicator<T>({
+  required BuildContext context,
+  required Future<T> Function() task,
+}) async {
+  // オーバーレイエントリを作成
+  final overlayEntry = OverlayEntry(
+    builder: (context) => Container(
+      color: Colors.black.withOpacity(0.3),
+      child: const Center(
+        child: CircularProgressIndicator(),
+      ),
+    ),
+  );
+
+  // オーバーレイにローディングインジケーターを挿入
+  Overlay.of(context).insert(overlayEntry);
+
+  try {
+    return await task();
+  } finally {
+    // タスクが完了したらオーバーレイを削除
+    overlayEntry.remove();
+  }
+}

--- a/lib/ui/utils/async_task_indicator.dart
+++ b/lib/ui/utils/async_task_indicator.dart
@@ -7,8 +7,8 @@ Future<T> performTaskWithLoadingIndicator<T>({
 }) async {
   // オーバーレイエントリを作成
   final overlayEntry = OverlayEntry(
-    builder: (context) => Container(
-      color: Colors.black.withOpacity(0.3),
+    builder: (context) => ColoredBox(
+      color: Colors.black.withAlpha(80),
       child: const Center(
         child: CircularProgressIndicator(),
       ),

--- a/test/weather_api_test.dart
+++ b/test/weather_api_test.dart
@@ -15,7 +15,7 @@ import 'weather_api_test.mocks.dart';
 void main() {
   test('''
         YumemiWeatherがcloudyを返す時、WeatherAPIは、cloudyを返す
-    ''', () {
+    ''', () async {
     final mock = MockYumemiWeather();
 
     final container = createContainer(
@@ -37,8 +37,8 @@ void main() {
     }
     ''';
 
-    when(mock.fetchWeather(any)).thenReturn(response);
-    expect(api.fetchWeatherInfo(), response);
+    when(mock.syncFetchWeather(any)).thenReturn(response);
+    expect(await api.fetchWeatherInfo(), response);
   });
 
   test('''
@@ -55,7 +55,8 @@ void main() {
 
     final api = container.read(weatherAPIProvider);
 
-    when(mock.fetchWeather(any)).thenThrow(YumemiWeatherError.invalidParameter);
+    when(mock.syncFetchWeather(any))
+        .thenThrow(YumemiWeatherError.invalidParameter);
     expect(api.fetchWeatherInfo, throwsA(isA<InvalidParameter>()));
   });
 
@@ -73,7 +74,7 @@ void main() {
 
     final api = container.read(weatherAPIProvider);
 
-    when(mock.fetchWeather(any)).thenThrow(YumemiWeatherError.unknown);
+    when(mock.syncFetchWeather(any)).thenThrow(YumemiWeatherError.unknown);
     expect(api.fetchWeatherInfo, throwsA(isA<Unknown>()));
   });
 }

--- a/test/weather_info_notifier_provider_test.dart
+++ b/test/weather_info_notifier_provider_test.dart
@@ -35,7 +35,7 @@ void main() {
     '''
        WeatherRepositoryが、「cloudyその他」を返す時、weatherInfoが「cloudyその他」になっていること
     ''',
-    () {
+    () async {
       final mock = MockWeatherRepository();
 
       final container = createContainer(
@@ -52,12 +52,12 @@ void main() {
         weatherCondition: WeatherCondition.cloudy,
       );
 
-      when(mock.getWeatherInfo()).thenReturn(
-        weatherForTest,
+      when(mock.getWeatherInfo()).thenAnswer(
+        (_) async => weatherForTest,
       );
 
       // fetchメソッドを実行
-      container.read(weatherInfoNotifierProvider.notifier).fetch();
+      await container.read(weatherInfoNotifierProvider.notifier).fetch();
 
       final weatherInfo = container.read(weatherInfoNotifierProvider);
 

--- a/test/weather_info_notifier_provider_test.mocks.dart
+++ b/test/weather_info_notifier_provider_test.mocks.dart
@@ -3,6 +3,8 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:async' as _i4;
+
 import 'package:flutter_training/data/repository/weather_repository.dart'
     as _i3;
 import 'package:flutter_training/domain/model/weather_info.dart' as _i2;
@@ -32,7 +34,7 @@ class _FakeWeatherInfo_0 extends _i1.SmartFake implements _i2.WeatherInfo {
 /// See the documentation for Mockito's code generation for more information.
 class MockWeatherRepository extends _i1.Mock implements _i3.WeatherRepository {
   @override
-  _i2.WeatherInfo getWeatherInfo({
+  _i4.Future<_i2.WeatherInfo> getWeatherInfo({
     String? area = 'tokyo',
     DateTime? dateTime,
   }) =>
@@ -41,20 +43,24 @@ class MockWeatherRepository extends _i1.Mock implements _i3.WeatherRepository {
               #area: area,
               #dateTime: dateTime,
             }),
-            returnValue: _FakeWeatherInfo_0(
-              this,
-              Invocation.method(#getWeatherInfo, [], {
-                #area: area,
-                #dateTime: dateTime,
-              }),
+            returnValue: _i4.Future<_i2.WeatherInfo>.value(
+              _FakeWeatherInfo_0(
+                this,
+                Invocation.method(#getWeatherInfo, [], {
+                  #area: area,
+                  #dateTime: dateTime,
+                }),
+              ),
             ),
-            returnValueForMissingStub: _FakeWeatherInfo_0(
-              this,
-              Invocation.method(#getWeatherInfo, [], {
-                #area: area,
-                #dateTime: dateTime,
-              }),
+            returnValueForMissingStub: _i4.Future<_i2.WeatherInfo>.value(
+              _FakeWeatherInfo_0(
+                this,
+                Invocation.method(#getWeatherInfo, [], {
+                  #area: area,
+                  #dateTime: dateTime,
+                }),
+              ),
             ),
           )
-          as _i2.WeatherInfo);
+          as _i4.Future<_i2.WeatherInfo>);
 }

--- a/test/weather_repository_test.dart
+++ b/test/weather_repository_test.dart
@@ -13,7 +13,7 @@ import 'weather_repository_test.mocks.dart';
 void main() {
   test('''
         Weather APIがresponseを返す時、WeatherRepositoryは、WeatherInfoを返す
-    ''', () {
+    ''', () async {
     final mock = MockWeatherAPI();
 
     const response = '''
@@ -35,9 +35,9 @@ void main() {
 
     final repository = container.read(weatherRepositoryProvider);
 
-    when(mock.fetchWeatherInfo()).thenReturn(response);
+    when(mock.fetchWeatherInfo()).thenAnswer((_) async => response);
     expect(
-      repository.getWeatherInfo(),
+      await repository.getWeatherInfo(),
       const WeatherInfo(
         maxTemperature: 25,
         minTemperature: 7,
@@ -48,7 +48,7 @@ void main() {
 
   test('''
         Weather APIがInvalidParameterをスローする時、WeatherRepositoryは、InvalidParameterをスローする
-    ''', () {
+    ''', () async {
     final mock = MockWeatherAPI();
 
     final container = createContainer(
@@ -70,7 +70,7 @@ void main() {
 
   test('''
         Weather APIがUnknownをスローする時、WeatherRepositoryは、Unknownをスローする
-    ''', () {
+    ''', () async {
     final mock = MockWeatherAPI();
 
     final container = createContainer(

--- a/test/weather_repository_test.mocks.dart
+++ b/test/weather_repository_test.mocks.dart
@@ -3,9 +3,11 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:async' as _i3;
+
 import 'package:flutter_training/data/api/weather_api.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i3;
+import 'package:mockito/src/dummies.dart' as _i4;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -26,28 +28,35 @@ import 'package:mockito/src/dummies.dart' as _i3;
 /// See the documentation for Mockito's code generation for more information.
 class MockWeatherAPI extends _i1.Mock implements _i2.WeatherAPI {
   @override
-  String fetchWeatherInfo({String? area = 'tokyo', DateTime? dateTime}) =>
+  _i3.Future<String> fetchWeatherInfo({
+    String? area = 'tokyo',
+    DateTime? dateTime,
+  }) =>
       (super.noSuchMethod(
             Invocation.method(#fetchWeatherInfo, [], {
               #area: area,
               #dateTime: dateTime,
             }),
-            returnValue: _i3.dummyValue<String>(
-              this,
-              Invocation.method(#fetchWeatherInfo, [], {
-                #area: area,
-                #dateTime: dateTime,
-              }),
+            returnValue: _i3.Future<String>.value(
+              _i4.dummyValue<String>(
+                this,
+                Invocation.method(#fetchWeatherInfo, [], {
+                  #area: area,
+                  #dateTime: dateTime,
+                }),
+              ),
             ),
-            returnValueForMissingStub: _i3.dummyValue<String>(
-              this,
-              Invocation.method(#fetchWeatherInfo, [], {
-                #area: area,
-                #dateTime: dateTime,
-              }),
+            returnValueForMissingStub: _i3.Future<String>.value(
+              _i4.dummyValue<String>(
+                this,
+                Invocation.method(#fetchWeatherInfo, [], {
+                  #area: area,
+                  #dateTime: dateTime,
+                }),
+              ),
             ),
           )
-          as String);
+          as _i3.Future<String>);
 
   @override
   Map<String, String> toJson(({String area, DateTime dateTime})? value) =>

--- a/test/weather_screen_test.dart
+++ b/test/weather_screen_test.dart
@@ -56,7 +56,9 @@ void main() {
     await tester.tap(reloadButton);
 
     // 再描画
-    await tester.pump();
+    //await tester.pump();
+
+    await tester.pumpAndSettle();
 
     // cloudyの名前のラベルを持つウィジェットを検索
     final weatherImage = find.bySemanticsLabel(WeatherCondition.cloudy.name);


### PR DESCRIPTION
## 課題

close #12 

- 使用する API を fetchWeather() から syncFetchWeather() に変更する
- API の処理が戻るまで [CircularProgressIndicator](https://api.flutter.dev/flutter/material/CircularProgressIndicator-class.html) を表示する

## 対応箇所

- WeatherAPI:fetchWeatherInfoをcompute対応にする
- fetchWeatherInfo()と呼び出し元をFuture<String>に対応する形に変更
- 非同期の実行中にローディングインジケーターを表示するための関数を実装
   - （Future<T> performTaskWithLoadingIndicator<T>）
- WeatherScreenの実装を変更し、上記の関数を利用する形にした

## 動作

| iOS | Android |
|----------|--------|
| <video width="320" src="https://github.com/user-attachments/assets/9ff65c29-8e57-4e5b-a2d4-f4c69fe31952">   |  <video width="320" src="https://github.com/user-attachments/assets/ab5c49ae-77e7-468f-b176-6805fc638f4a"> |








